### PR TITLE
Rearranged artifacts and added kustomize related files

### DIFF
--- a/sostrades/deploy/base/integration/configmaps/api-sostrades-api-conf.yaml
+++ b/sostrades/deploy/base/integration/configmaps/api-sostrades-api-conf.yaml
@@ -1,0 +1,68 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: api-sostrades-api-conf
+  namespace: sostrades
+  labels:
+    app.kubernetes.io/component: sostrades-api
+data:
+  sostrades_configuration.json: |-
+    {
+      "ENVIRONMENT": "PRODUCTION",
+    
+      "SQL_ALCHEMY_DATABASE": {
+        "HOST" : "mysql.sostrades.svc.cluster.local",
+        "PORT" : 3306,
+        "USER_ENV_VAR": "SQL_ACCOUNT",
+        "PASSWORD_ENV_VAR": "SQL_PASSWORD",
+        "DATABASE_NAME": "sostrades-data",
+        "SSL": true
+      },
+    
+      "SQLALCHEMY_TRACK_MODIFICATIONS": false,
+    
+    
+      "LOGGING_DATABASE": {
+        "HOST" : "mysql.sostrades.svc.cluster.local",
+        "PORT" : 3306,
+        "USER_ENV_VAR": "LOG_USER",
+        "PASSWORD_ENV_VAR": "LOG_PASSWORD",
+        "DATABASE_NAME": "sostrades-log",
+        "SSL": true
+      },
+    
+      "SECRET_KEY_ENV_VAR": "SECRET_KEY",
+    
+      "JWT_TOKEN_LOCATION": "headers",
+      "JWT_ACCESS_TOKEN_EXPIRES": 18000,
+      "JWT_REFRESH_TOKEN_EXPIRES": 36000,
+    
+      "DEFAULT_GROUP_MANAGER_ACCOUNT": "All_users",
+    
+      "CREATE_STANDARD_USER_ACCOUNT": false,
+    
+      "LDAP_SERVER" : "",
+      "LDAP_BASE_DN" : "",
+      "LDAP_FILTER" : "",
+      "LDAP_USERNAME" : "",
+    
+      "SMTP_SERVER" : "",
+      "SMTP_SOS_TRADES_ADDR" : "",
+    
+      "SOS_TRADES_ENVIRONMENT" : "Public OSC",
+      "SOS_TRADES_K8S_DNS": "",
+      "SOS_TRADES_FRONT_END_DNS": "https://frontend-sostrades.apps.odh-cl2.apps.os-climate.org/",
+      "SOS_TRADES_ONTOLOGY_ENDPOINT": "http://ontology.sostrades.svc.cluster.local:5555/api/ontology",
+    
+      "SOS_TRADES_PROCESS_REPOSITORY": [],
+    
+      "SOS_TRADES_EXECUTION_STRATEGY": "subprocess",
+      "SOS_TRADES_SERVER_MODE": "mono",
+      "SOS_TRADES_DATA": "/sostdata",
+      "SOS_TRADES_REFERENCES": "/sostdata/references",
+      "EEB_PATH": "/startup/eeb.yaml",
+      "SOS_TRADES_RSA": "/usr/local/sostrades/conf/rsa-key/",
+    
+      "INTERNAL_SSL_CERTIFICATE": ""
+    
+    }

--- a/sostrades/deploy/base/integration/configmaps/api-sostrades-api-scripts.yaml
+++ b/sostrades/deploy/base/integration/configmaps/api-sostrades-api-scripts.yaml
@@ -1,0 +1,79 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: api-sostrades-api-scripts
+  namespace: sostrades
+  labels:
+    app.kubernetes.io/component: sostrades-api
+data:
+  commands.sh: >-
+    ## Update application
+
+
+    echo 'Update SoSTrades application......'
+
+
+    ## Set PythonPath
+
+    ls -d $SOS_TRADES_SOURCES/*/ | tr '\n' ':' > /tmp/pythonpath.txt
+
+    export PYTHONPATH=$(cat /tmp/pythonpath.txt)
+
+    export
+    PYTHONPATH=/usr/local/sostrades/sources/sostrades-core:/usr/local/sostrades/sources/sostrades-value-assessment:/usr/local/sostrades/sources/sostrades-webapi:/usr/local/sostrades/sources/sosgemseo/src:/usr/local/sostrades/sources/witness-energy:/usr/local/sostrades/sources/witness-core
+
+    pip install importlib-metadata==4.13.0
+
+
+    echo $PYTHONPATH
+
+    echo 'Done!'
+
+    cd $SOS_TRADES_SOURCES
+
+    . ./sostrades-env/bin/activate
+
+    cd $SOS_TRADES_SOURCES/sostrades-webapi
+
+
+    flask db upgrade
+
+
+    flask init_process
+
+    flask create_standard_user testuser user@test.com test user
+    
+    flask change_user_profile testuser -p "Study manager"
+
+
+    gunicorn sos_trades_api.server.split_mode.post_processing_server:app --bind
+    0.0.0.0:8003 --limit-request-line 0 --timeout 300 -D
+    --enable-stdio-inheritance
+
+    ## If tls internal enabled : --certfile=/etc/ssl/private/tls.crt
+    --keyfile=/etc/ssl/private/tls.key
+
+
+    gunicorn --worker-class eventlet sos_trades_api.server.message_server:app
+    --bind 0.0.0.0:8002 --limit-request-line 0 --timeout 300 -D
+    --enable-stdio-inheritance
+
+    ## If tls internal enabled : --certfile=/etc/ssl/private/tls.crt
+    --keyfile=/etc/ssl/private/tls.key
+
+
+
+    gunicorn sos_trades_api.server.split_mode.data_server:app --bind
+    0.0.0.0:8001 --limit-request-line 0 --timeout 300 -D
+    --enable-stdio-inheritance -w 5
+
+    ## If tls internal enabled : --certfile=/etc/ssl/private/tls.crt
+    --keyfile=/etc/ssl/private/tls.key
+
+
+
+    gunicorn sos_trades_api.server.split_mode.main_server:app  --bind
+    0.0.0.0:8000 --limit-request-line 0 --timeout 300
+
+    ## If tls internal enabled : --certfile=/etc/ssl/private/tls.crt
+    --keyfile=/etc/ssl/private/tls.key

--- a/sostrades/deploy/base/integration/configmaps/frontend-sostrades-frontend-config.yaml
+++ b/sostrades/deploy/base/integration/configmaps/frontend-sostrades-frontend-config.yaml
@@ -1,0 +1,104 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: frontend-sostrades-frontend-config
+  namespace: sostrades
+data:
+  default.conf: >
+    # ssl_certificate     /root/certs/sst-fe/tls.crt;
+
+    # ssl_certificate_key /root/certs/sst-fe/tls.key;
+
+    # ssl_ciphers         EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH;
+
+    # ssl_prefer_server_ciphers on;
+
+    # ssl_protocols       TLSv1.2;
+
+    # ssl_session_timeout 5m;
+
+    # ssl_session_cache shared:SSL:50m;
+
+    # ssl_session_tickets off;
+
+    ssl off;
+
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;
+    preload"; add_header Content-Security-Policy "default-src 'self'; img-src
+    'self' data: blob:; font-src 'self'; style-src 'self' 'unsafe-inline'
+    ;script-src 'self' 'unsafe-eval' 'unsafe-inline'; connect-src
+    'self';frame-ancestors *"; add_header X-XSS-Protection "1; mode=block";
+    server_tokens off;
+
+    server {
+
+        listen       8080  default_server;
+
+        server_name  frontend.sostrades.svc.cluster.local;
+        server_tokens off;
+        client_max_body_size 100M;
+
+        location / {
+            limit_except GET DELETE POST { deny all; }
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri $uri/ /index.html;
+            expires -1;
+        }
+
+        location /api/main {
+            limit_except GET DELETE POST { deny all; }
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_pass http://api.sostrades.svc.cluster.local:8000;
+            fastcgi_read_timeout 300;
+            proxy_read_timeout 300;
+        }
+
+        location /api/data {
+            limit_except GET DELETE POST { deny all; }
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_pass http://api.sostrades.svc.cluster.local:8001;
+            fastcgi_read_timeout 300;
+            proxy_read_timeout 300;
+        }
+
+        # location /saml/acs {
+        #     limit_except GET DELETE POST { deny all; }
+        #     proxy_set_header X-Forwarded-Host $host:$server_port;
+        #     proxy_set_header X-Forwarded-Server $host;
+        #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        #     proxy_pass :8000;
+        # }
+
+        location /socket.io {
+            limit_except GET DELETE POST { deny all; }
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_pass http://api.sostrades.svc.cluster.local:8002;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        location /api/post-processing {
+            limit_except GET DELETE POST { deny all; }
+            proxy_set_header X-Forwarded-Host $host:$server_port;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_pass http://api.sostrades.svc.cluster.local:8003;
+            fastcgi_read_timeout 300;
+            proxy_read_timeout 300;
+        }
+
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+
+    }

--- a/sostrades/deploy/base/integration/configmaps/kustomization.yaml
+++ b/sostrades/deploy/base/integration/configmaps/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- api-sostrades-api-conf.yaml
+- api-sostrades-api-scripts.yaml
+- frontend-sostrades-frontend-config.yaml

--- a/sostrades/deploy/base/integration/deployment/api.yaml
+++ b/sostrades/deploy/base/integration/deployment/api.yaml
@@ -1,0 +1,155 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+##  annotations:
+##    image.openshift.io/triggers: >-
+##      [{"from":{"kind":"ImageStreamTag","name":"api:latest","namespace":"sostrades"},"fieldPath":"spec.template.spec.containers[?(@.name==\"api\")].image","pause":"false"}]
+##    openshift.io/generated-by: OpenShiftWebConsole
+  name: api
+  namespace: sostrades
+  labels:
+    app: api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/instance: api
+    app.kubernetes.io/name: api
+    app.kubernetes.io/part-of: sostrades
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: api
+        deploymentconfig: api
+    spec:
+      volumes:
+        - name: sostrades-api-scripts
+          configMap:
+            name: api-sostrades-api-scripts
+            items:
+              - key: commands.sh
+                path: commands.sh
+            defaultMode: 420
+        - name: sostrades-api-conf
+          configMap:
+            name: api-sostrades-api-conf
+            items:
+              - key: sostrades_configuration.json
+                path: sostrades_configuration.json
+            defaultMode: 420
+        - name: sostrades-rsa-key
+          secret:
+            secretName: api-sostrades-api-rsa-key
+            items:
+              - key: private_key.pem
+                path: private_key.pem
+              - key: public_key.pem
+                path: public_key.pem
+            defaultMode: 420
+        - name: sostrades-github-oauth
+          secret:
+            secretName: githuboauth
+            defaultMode: 420
+        - name: sostrades-api-data-pvc
+          persistentVolumeClaim:
+            claimName: sostrades-api-data-pvc
+      containers:
+        - resources:
+            limits:
+              cpu: '1'
+              memory: 2Gi
+            requests:
+              cpu: '1'
+              memory: 1Gi
+          terminationMessagePath: /dev/termination-log
+          name: api
+          env:
+            - name: SOS_TRADES_DATA
+              value: /sostdata
+            - name: SOS_TRADES_REFERENCES
+              value: /sostdata/references
+            - name: SOS_TRADES_SOURCES
+              value: /usr/local/sostrades/sources
+            - name: SOS_TRADES_SERVER_CONFIGURATION
+              value: /usr/local/sostrades/conf/sostrades_configuration.json
+            - name: SOS_TRADES_RSA
+              value: /usr/local/sostrades/conf/rsa-key/
+            - name: K8S_NAMESPACE
+              value: sostrades
+            - name: SOS_TRADES_EXECUTION_STRATEGY
+              value: subprocess
+            - name: SECRET_KEY
+              value: '?~z#_9*UqOFK:`la_4nO&G`a2m;tF!'
+            - name: SQL_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: api-sostrades-api-db-data
+                  key: username
+            - name: SQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: api-sostrades-api-db-data
+                  key: password
+            - name: LOG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: api-sostrades-api-db-log
+                  key: username
+            - name: LOG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: api-sostrades-api-db-log
+                  key: password
+            - name: GITHUB_OAUTH_SETTINGS
+              value: /usr/local/sostrades/conf/github-oauth-settings/settings.json
+            - name: SAML_V2_METADATA_FOLDER
+              value: /usr/local/sostrades/conf/saml-v2/
+            - name: SOS_TRADES_SERVER_MODE
+              value: mono
+          ports:
+            - name: api
+              containerPort: 8000
+              protocol: TCP
+            - name: api-data
+              containerPort: 8001
+              protocol: TCP
+            - name: api-message
+              containerPort: 8002
+              protocol: TCP
+            - name: https
+              containerPort: 8003
+              protocol: TCP
+          imagePullPolicy: Never
+          volumeMounts:
+            - name: sostrades-api-scripts
+              mountPath: /startup/
+            - name: sostrades-api-conf
+              mountPath: /usr/local/sostrades/conf/
+            - name: sostrades-rsa-key
+              mountPath: /usr/local/sostrades/conf/rsa-key/
+            - name: sostrades-github-oauth
+              mountPath: /usr/local/sostrades/conf/github-oauth-settings/
+            - name: sostrades-api-data-pvc
+              mountPath: /sostdata
+          terminationMessagePolicy: File
+          image: >-
+            registry/sostrades/api:latest
+#            image-registry.openshift-image-registry.svc:5000/sostrades/api:latest
+#            docker.io/library/api:latest
+
+
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/sostrades/deploy/base/integration/deployment/frontend.yaml
+++ b/sostrades/deploy/base/integration/deployment/frontend.yaml
@@ -1,0 +1,64 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: frontend
+  namespace: sostrades
+  labels:
+    app: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/instance: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: sostrades
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: frontend
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/name: frontend
+        deploymentconfig: frontend
+    spec:
+      volumes:
+        - name: default-conf
+          configMap:
+            name: frontend-sostrades-frontend-config
+            items:
+              - key: default.conf
+                path: default.conf
+            defaultMode: 420
+      containers:
+        - name: frontend
+          image: >-
+            registry/sostrades/frontend:latest
+#            docker.io/library/frontend:1
+          resources:
+            limits:
+              cpu: 800m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 500Mi
+          volumeMounts:
+            - name: default-conf
+              readOnly: true
+              mountPath: /etc/nginx/conf.d/
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Never
+      restartPolicy: Always          
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/sostrades/deploy/base/integration/deployment/kustomization.yaml
+++ b/sostrades/deploy/base/integration/deployment/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- api.yaml
+- frontend.yaml

--- a/sostrades/deploy/base/integration/kustomization.yaml
+++ b/sostrades/deploy/base/integration/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- configmaps
+- secret
+- pv
+- pvc
+- deployment
+- service
+- route

--- a/sostrades/deploy/base/integration/pv/kustomization.yaml
+++ b/sostrades/deploy/base/integration/pv/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- mysql-integration-pv.yaml
+- mysql-sostrades-pv.yaml
+- sostrades-api-data-pv.yaml

--- a/sostrades/deploy/base/integration/pv/mysql-integration-pv.yaml
+++ b/sostrades/deploy/base/integration/pv/mysql-integration-pv.yaml
@@ -1,0 +1,15 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: mysql-integration-pv
+spec:
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /mnt/data
+    type: ''
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: slow
+  volumeMode: Filesystem

--- a/sostrades/deploy/base/integration/pv/mysql-sostrades-pv.yaml
+++ b/sostrades/deploy/base/integration/pv/mysql-sostrades-pv.yaml
@@ -1,0 +1,15 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: mysql-sostrades-pv
+spec:
+  capacity:
+    storage: 3Gi
+  hostPath:
+    path: /mnt/data
+    type: ''
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: slow
+  volumeMode: Filesystem

--- a/sostrades/deploy/base/integration/pv/sostrades-api-data-pv.yaml
+++ b/sostrades/deploy/base/integration/pv/sostrades-api-data-pv.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: sostrades-api-data-pv
+spec:
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /mnt/data
+    type: ''
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem

--- a/sostrades/deploy/base/integration/pvc/kustomization.yaml
+++ b/sostrades/deploy/base/integration/pvc/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- mysql-sostrades-pvc.yaml
+- sostrades-api-data-pvc.yaml

--- a/sostrades/deploy/base/integration/pvc/mysql-sostrades-pvc.yaml
+++ b/sostrades/deploy/base/integration/pvc/mysql-sostrades-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-sostrades-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi

--- a/sostrades/deploy/base/integration/pvc/sostrades-api-data-pvc.yaml
+++ b/sostrades/deploy/base/integration/pvc/sostrades-api-data-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sostrades-api-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/sostrades/deploy/base/integration/route/frontend.yaml
+++ b/sostrades/deploy/base/integration/route/frontend.yaml
@@ -1,0 +1,22 @@
+kind: Route
+apiVersion: v1
+metadata:
+  name: frontend
+  namespace: sostrades
+  labels:
+    app: frontend
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/instance: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/part-of: sostrades
+  annotations:
+    kubernetes.io/tls-acme: 'true'
+    openshift.io/host.generated: 'true'
+spec:
+  host: 127.0.0.1:8089
+  to:
+    kind: Service
+    name: frontend
+    weight: 100
+  port:
+    targetPort: 8080-tcp

--- a/sostrades/deploy/base/integration/route/kustomization.yaml
+++ b/sostrades/deploy/base/integration/route/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- frontend.yaml

--- a/sostrades/deploy/base/integration/secret/api-db-secret.yaml
+++ b/sostrades/deploy/base/integration/secret/api-db-secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: api-db-secret
+data:
+  username: c29zdHJhZGVz
+  password: c29zdHJhZGVz
+type: Opaque

--- a/sostrades/deploy/base/integration/secret/api-sostrades-api-db-data.yaml
+++ b/sostrades/deploy/base/integration/secret/api-sostrades-api-db-data.yaml
@@ -1,0 +1,9 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: api-sostrades-api-db-data
+  namespace: sostrades
+data:
+  password: YWRtaW4=
+  username: c29zdHJhZGVz
+type: Opaque

--- a/sostrades/deploy/base/integration/secret/api-sostrades-api-db-log.yaml
+++ b/sostrades/deploy/base/integration/secret/api-sostrades-api-db-log.yaml
@@ -1,0 +1,9 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: api-sostrades-api-db-log
+  namespace: sostrades
+data:
+  password: YWRtaW4=
+  username: c29zdHJhZGVz
+type: Opaque

--- a/sostrades/deploy/base/integration/secret/api-sostrades-api-rsa-key.yaml
+++ b/sostrades/deploy/base/integration/secret/api-sostrades-api-rsa-key.yaml
@@ -1,0 +1,10 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: api-sostrades-api-rsa-key
+  namespace: sostrades
+data:
+  private_key.pem: ''
+  public_key.pem: ''
+type: Opaque
+

--- a/sostrades/deploy/base/integration/secret/githuboauth.yaml
+++ b/sostrades/deploy/base/integration/secret/githuboauth.yaml
@@ -1,0 +1,10 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: githuboauth
+  namespace: sostrades
+data:
+  settings.json: >-
+    ewogICAgIkdJVEhVQl9DTElFTlRfSUQiOiAiY2ZjOWVjZjc2MmQ2NjhkYWM0MWQiLAogICAgIkdJVEhVQl9DTElFTlRfU0VDUkVUIjogIjk3NzFjMzRiYzAyNzZkNDNlYzIwOWI5ZWM5NDk1ZDNmZTA3NjRhYTQiLAogICAgIkdJVEhVQl9BUElfVVJMIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vIiwKICAgICJHSVRIVUJfQVVUSF9VUkwiOiAiaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoLyIKfQ==
+
+type: Opaque

--- a/sostrades/deploy/base/integration/secret/kustomization.yaml
+++ b/sostrades/deploy/base/integration/secret/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- api-db-secret.yaml
+- log-db-secret.yaml
+- api-sostrades-api-db-data.yaml
+- api-sostrades-api-db-log.yaml
+- api-sostrades-api-rsa-key.yaml
+- githuboauth.yaml
+- mysql-sostrades-password.yaml

--- a/sostrades/deploy/base/integration/secret/log-db-secret.yaml
+++ b/sostrades/deploy/base/integration/secret/log-db-secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: log-db-secret
+data:
+  password: c29zdHJhZGVzX3Byb2R1Y3Rpb25fbG9n
+  username: c29zdHJhZGVzX3Byb2R1Y3Rpb25fbG9n
+type: Opaque

--- a/sostrades/deploy/base/integration/secret/mysql-sostrades-password.yaml
+++ b/sostrades/deploy/base/integration/secret/mysql-sostrades-password.yaml
@@ -1,0 +1,9 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: mysql-sostrades-password
+  namespace: sostrades
+data:
+  mysql-password: YWRtaW4=
+  mysql-root-password: YWRtaW4=
+type: Opaque

--- a/sostrades/deploy/base/integration/service/api.yaml
+++ b/sostrades/deploy/base/integration/service/api.yaml
@@ -1,0 +1,32 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: api
+  namespace: sostrades
+spec:
+  ports:
+    - name: api
+      protocol: TCP
+      port: 8000
+      targetPort: 8000
+    - name: api-data
+      protocol: TCP
+      port: 8001
+      targetPort: 8001
+    - name: api-message
+      protocol: TCP
+      port: 8002
+      targetPort: 8002
+    - name: https
+      protocol: TCP
+      port: 8003
+      targetPort: 8003
+    - name: api-v0
+      protocol: TCP
+      port: 8004
+      targetPort: 8004
+  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  selector:
+    app: api
+    deploymentconfig: api

--- a/sostrades/deploy/base/integration/service/frontend.yaml
+++ b/sostrades/deploy/base/integration/service/frontend.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: frontend
+  namespace: sostrades
+  labels:
+    app: frontend
+spec:
+  ports:
+    - name: 8080-tcp
+      protocol: TCP
+      port: 8089
+      targetPort: 8080
+  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app: frontend
+    deploymentconfig: frontend

--- a/sostrades/deploy/base/integration/service/kustomization.yaml
+++ b/sostrades/deploy/base/integration/service/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- api.yaml
+- frontend.yaml

--- a/sostrades/deploy/base/mysql/configmap/kustomization.yaml
+++ b/sostrades/deploy/base/mysql/configmap/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- mysql-sostrades-conf.yaml
+- mysql-sostrades-init-scripts.yaml

--- a/sostrades/deploy/base/mysql/configmap/mysql-sostrades-conf.yaml
+++ b/sostrades/deploy/base/mysql/configmap/mysql-sostrades-conf.yaml
@@ -1,0 +1,35 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: mysql-sostrades-conf
+  namespace: sostrades
+data:
+  my.cnf: |-
+
+    [mysqld]
+    default_authentication_plugin=mysql_native_password
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/mysql
+    plugin_dir=/opt/mysql/lib/plugin
+    port=3306
+    socket=/opt/mysql/tmp/mysql.sock
+    datadir=/mysql/data
+    tmpdir=/opt/mysql/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/mysql/tmp/mysqld.pid
+    log-error=/opt/mysql/logs/mysqld.log
+    character-set-server=UTF8
+    collation-server=utf8_general_ci
+
+    [client]
+    port=3306
+    socket=/opt/mysql/tmp/mysql.sock
+    default-character-set=UTF8
+    plugin_dir=/opt/mysql/lib/plugin
+
+    [manager]
+    port=3306
+    socket=/opt/mysql/tmp/mysql.sock
+    pid-file=/opt/mysql/tmp/mysqld.pid

--- a/sostrades/deploy/base/mysql/configmap/mysql-sostrades-init-scripts.yaml
+++ b/sostrades/deploy/base/mysql/configmap/mysql-sostrades-init-scripts.yaml
@@ -1,0 +1,31 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: mysql-sostrades-init-scripts
+  namespace: sostrades
+data:
+  my_init_script.sql: >
+    CREATE DATABASE `sostrades-data`;
+
+    CREATE DATABASE `sostrades-log`;
+
+    CREATE DATABASE `sostrades-data-validation`;
+
+    CREATE DATABASE `sostrades-log-validation`;
+
+    CREATE USER 'sostrades'@'%' IDENTIFIED BY 'admin';
+
+    GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, REFERENCES, SELECT, UPDATE
+    ON `sostrades-data`.* TO 'sostrades'@'%';
+
+    GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, REFERENCES, SELECT, UPDATE
+    ON `sostrades-log`.* TO 'sostrades'@'%';
+
+    GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, REFERENCES, SELECT, UPDATE
+    ON `sostrades-data-validation`.* TO 'sostrades'@'%';
+
+    GRANT ALTER, CREATE, DELETE, DROP, INDEX, INSERT, REFERENCES, SELECT, UPDATE
+    ON `sostrades-log-validation`.* TO 'sostrades'@'%';
+
+
+    FLUSH PRIVILEGES;

--- a/sostrades/deploy/base/mysql/kustomization.yaml
+++ b/sostrades/deploy/base/mysql/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- configmap
+- service
+- statefulset

--- a/sostrades/deploy/base/mysql/service/kustomization.yaml
+++ b/sostrades/deploy/base/mysql/service/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- mysql.yaml

--- a/sostrades/deploy/base/mysql/service/mysql.yaml
+++ b/sostrades/deploy/base/mysql/service/mysql.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: mysql
+  namespace: sostrades
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3306
+      targetPort: 3306
+  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/instance: mysql-sostrades
+    app.kubernetes.io/name: mysql-sostrades

--- a/sostrades/deploy/base/mysql/statefulset/kustomization.yaml
+++ b/sostrades/deploy/base/mysql/statefulset/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- mysql.yaml

--- a/sostrades/deploy/base/mysql/statefulset/mysql.yaml
+++ b/sostrades/deploy/base/mysql/statefulset/mysql.yaml
@@ -1,0 +1,127 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: mysql-sostrades
+  namespace: sostrades
+  labels:
+    app: mysql-sostrades
+    app.kubernetes.io/part-of: sostrades
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: mysql-sostrades
+      app.kubernetes.io/name: mysql-sostrades
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: mysql-sostrades
+        app.kubernetes.io/name: mysql-sostrades
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: mysql-sostrades-conf
+            defaultMode: 420
+        - name: custom-init-scripts
+          configMap:
+            name: mysql-sostrades-init-scripts
+            defaultMode: 420
+        - name: data
+          persistentVolumeClaim:
+            claimName: mysql-sostrades-pvc
+      containers:
+        - resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 64Mi
+#          readinessProbe:
+#            exec:
+#              command:
+#                - /bin/bash
+#                - '-ec'
+#                - |
+#                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
+#                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+#                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+#                  fi
+#                  mysqladmin status -uroot -p"${password_aux}"
+#            timeoutSeconds: 1
+#            periodSeconds: 10
+#            successThreshold: 1
+#            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: mysql
+#          livenessProbe:
+#            exec:
+#              command:
+#                - /bin/bash
+#                - '-ec'
+#                - |
+#                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
+#                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+#                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+#                  fi
+#                  mysqladmin status -uroot -p"${password_aux}"
+#            timeoutSeconds: 1
+#            periodSeconds: 10
+#            successThreshold: 1
+#            failureThreshold: 3
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-sostrades-password
+                  key: mysql-root-password
+##              value: admin
+##change to value from secret              
+            - name: MYSQL_DATABASE
+              value: my_database
+          securityContext: {}
+          ports:
+            - name: mysql
+              containerPort: 3306
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+#          startupProbe:
+#            exec:
+#              command:
+#                - /bin/bash
+#                - '-ec'
+#                - |
+#                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
+#                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+#                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+#                  fi
+#                  mysqladmin status -uroot -p"${password_aux}"
+#                - mysqladmin status -uroot -padmin
+#            timeoutSeconds: 1
+#            periodSeconds: 10
+#            successThreshold: 1
+#            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+            - name: config
+              mountPath: /opt/mysql/conf/my.cnf
+              subPath: my.cnf
+          terminationMessagePolicy: File
+          image: 'mysql:latest'
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  serviceName: mysql-sostrades
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
+  revisionHistoryLimit: 10

--- a/sostrades/deploy/base/ontology/deployment/kustomization.yaml
+++ b/sostrades/deploy/base/ontology/deployment/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- ontology.yaml

--- a/sostrades/deploy/base/ontology/deployment/ontology.yaml
+++ b/sostrades/deploy/base/ontology/deployment/ontology.yaml
@@ -1,0 +1,54 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+#  annotations:
+#    image.openshift.io/triggers: >-
+#      [{"from":{"kind":"ImageStreamTag","name":"ontology:latest","namespace":"sostrades"},"fieldPath":"spec.template.spec.containers[?(@.name==\"ontology\")].image","pause":"false"}]
+#    openshift.io/generated-by: OpenShiftWebConsole
+  name: ontology
+  namespace: sostrades
+  labels:
+    app: ontology
+    app.kubernetes.io/component: ontology
+    app.kubernetes.io/instance: ontology
+    app.kubernetes.io/name: ontology
+    app.kubernetes.io/part-of: sostrades
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ontology
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: ontology
+        deploymentconfig: ontology
+    spec:
+      containers:
+        - name: ontology
+          image: >-
+            docker.io/library/ontology:latest
+#            image-registry.openshift-image-registry.svc:5000/sostrades/ontology@sha256:867dbb1a8b9e0feda302d021410859f45c7064d34b1361a2b4628b96179ad09d
+          resources:
+            limits:
+              cpu: 1200m
+              memory: 2400Mi
+            requests:
+              cpu: 600m
+              memory: 1200Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: Never
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/sostrades/deploy/base/ontology/kustomization.yaml
+++ b/sostrades/deploy/base/ontology/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- deployment
+- service

--- a/sostrades/deploy/base/ontology/service/kustomization.yaml
+++ b/sostrades/deploy/base/ontology/service/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- ontology.yaml

--- a/sostrades/deploy/base/ontology/service/ontology.yaml
+++ b/sostrades/deploy/base/ontology/service/ontology.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ontology
+  namespace: sostrades
+spec:
+  ports:
+    - name: api
+      protocol: TCP
+      port: 5555
+      targetPort: 5555
+  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  selector:
+    app: ontology
+    deploymentconfig: ontology

--- a/sostrades/deploy/overlays/osc/osc-cl2/kustomization.yaml
+++ b/sostrades/deploy/overlays/osc/osc-cl2/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: sostrades
+resources:
+- ../../../base/integration
+- ../../../base/mysql
+- ../../../base/ontology


### PR DESCRIPTION
Added deploy directory with all artifacts to work with kustomize . Introduced following changes to the original structure:
- definitions of all secrets, pv , pvc and services were split to separate yaml files 
- objects of particular type were moved to separate directories , eg. deployments into deployment , pv into pv
- each directory for the objects now include kustomization.yaml file that defines which objects will be created 
- kustomization.yaml in overlays directory applies all components in base as is without modification (If changes specific to the cluster needed , this is the place to apply them  
